### PR TITLE
Battery tile: allow to disable custom battery style [2/2]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -478,5 +478,7 @@
     <string name="status_bar_battery_percentage_default">Hidden</string>
     <string name="status_bar_battery_percentage_text_inside">Inside the icon</string>
     <string name="status_bar_battery_percentage_text_next">Next to the icon</string>
+    <string name="status_bar_battery_style_tile_title">Custom battery tile style</string>
+    <string name="status_bar_battery_style_tile_summary">Allow to set the same icon style chosen for the statusbar battery</string>
 
 </resources>

--- a/res/xml/statusbar_battery_style.xml
+++ b/res/xml/statusbar_battery_style.xml
@@ -35,4 +35,9 @@
         android:entryValues="@array/status_bar_battery_percentage_values"
         android:defaultValue="0" />
 
+    <com.dirtyunicorns.dutweaks.preference.SecureSettingSwitchPreference
+        android:key="status_bar_battery_style_tile"
+        android:title="@string/status_bar_battery_style_tile_title"
+        android:summary="@string/status_bar_battery_style_tile_summary"
+        android:defaultValue="true" />
 </PreferenceScreen>

--- a/src/com/dirtyunicorns/dutweaks/fragments/StatusbarBatteryStyle.java
+++ b/src/com/dirtyunicorns/dutweaks/fragments/StatusbarBatteryStyle.java
@@ -56,7 +56,9 @@ public class StatusbarBatteryStyle extends SettingsPreferenceFragment implements
 
     private static final String STATUS_BAR_BATTERY_STYLE = "status_bar_battery_style";
     private static final String STATUS_BAR_SHOW_BATTERY_PERCENT = "status_bar_show_battery_percent";
+    private static final String STATUS_BAR_BATTERY_STYLE_TILE = "status_bar_battery_style_tile";
 
+    private static final int STATUS_BAR_BATTERY_STYLE_PORTRAIT = 0;
     private static final int STATUS_BAR_BATTERY_STYLE_HIDDEN = 4;
     private static final int STATUS_BAR_BATTERY_STYLE_TEXT = 6;
 
@@ -64,6 +66,7 @@ public class StatusbarBatteryStyle extends SettingsPreferenceFragment implements
     private ListPreference mStatusBarBatteryShowPercent;
     private int mStatusBarBatteryValue;
     private int mStatusBarBatteryShowPercentValue;
+    private SwitchPreference mQsBatteryTitle;
 
     @Override
     protected int getMetricsCategory() {
@@ -77,6 +80,11 @@ public class StatusbarBatteryStyle extends SettingsPreferenceFragment implements
 
         PreferenceScreen prefScreen = getPreferenceScreen();
         ContentResolver resolver = getActivity().getContentResolver();
+
+        mQsBatteryTitle = (SwitchPreference) findPreference(STATUS_BAR_BATTERY_STYLE_TILE);
+        mQsBatteryTitle.setChecked((Settings.Secure.getInt(resolver,
+                Settings.Secure.STATUS_BAR_BATTERY_STYLE_TILE, 1) == 1));
+        mQsBatteryTitle.setOnPreferenceChangeListener(this);
 
         mStatusBarBattery = (ListPreference) findPreference(STATUS_BAR_BATTERY_STYLE);
         mStatusBarBatteryValue = Settings.Secure.getInt(resolver,
@@ -120,6 +128,10 @@ public class StatusbarBatteryStyle extends SettingsPreferenceFragment implements
                     mStatusBarBatteryShowPercent.getEntries()[index]);
             Settings.Secure.putInt(getContentResolver(),
                     Settings.Secure.STATUS_BAR_SHOW_BATTERY_PERCENT, mStatusBarBatteryShowPercentValue);
+        } else if  (preference == mQsBatteryTitle) {
+            boolean checked = ((SwitchPreference)preference).isChecked();
+            Settings.Secure.putInt(getActivity().getContentResolver(),
+                    Settings.Secure.STATUS_BAR_BATTERY_STYLE_TILE, checked ? 1:0);
         }
 
         return true;
@@ -129,8 +141,12 @@ public class StatusbarBatteryStyle extends SettingsPreferenceFragment implements
         if (batteryIconStyle == STATUS_BAR_BATTERY_STYLE_HIDDEN ||
                 batteryIconStyle == STATUS_BAR_BATTERY_STYLE_TEXT) {
             mStatusBarBatteryShowPercent.setEnabled(false);
+            mQsBatteryTitle.setEnabled(false);
+        } else if (batteryIconStyle == STATUS_BAR_BATTERY_STYLE_PORTRAIT) {
+            mQsBatteryTitle.setEnabled(false);
         } else {
             mStatusBarBatteryShowPercent.setEnabled(true);
+            mQsBatteryTitle.setEnabled(true);
         }
     }
 


### PR DESCRIPTION
- Disable battery tile toggle when style is enabled for portrait, text 
or hidden.

Change-Id: I4e6f7c1bb5f3dd35919d59f9b7b4cf828854125b